### PR TITLE
[mod] Always trust internal keycloak ca in scanning image

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cloudflare/cfssl/log"
 	"github.com/docker/distribution/registry/client/auth/challenge"
 	apiv1 "github.com/tmax-cloud/registry-operator/api/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -170,7 +169,7 @@ func (r *RegistryAPI) GetToken(scope string) (*Token, error) {
 }
 
 func (r *RegistryAPI) fetchToken(scope string) (*Token, error) {
-	log.Info("Fetching token...")
+	logger.Info("Fetching token...")
 	server := r.Scheme + r.ServerURL
 	// Ping
 	u, err := url.Parse(server)


### PR DESCRIPTION
image scanning시 registry-operator에서 사용하는 keycloak의 인증서를 항상 신뢰할 수 있도록 수정
이유1: keycloak의 인증서가 registry에서 사용하는 root ca로 신뢰할 수 없는 인증서 일 수 있음
이유2: registry-operator에서 사용하는 keycloak의 인증서를 registry-system에서 관리하기 때문에 user가 알수 없음