### PR TITLE
Fix/imagescanrequest spec

### DIFF
--- a/api/v1/imagescanrequest_types.go
+++ b/api/v1/imagescanrequest_types.go
@@ -17,8 +17,6 @@ limitations under the License.
 package v1
 
 import (
-	"time"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -40,26 +38,10 @@ type ScanTarget struct {
 	RegistryURL string `json:"registryUrl"`
 	// Image path (example: library/alpine:3)
 	Images []string `json:"images"`
-	// Alternate URL for registry authentication (example: auth.docker.io)
-	AuthURL string `json:"authUrl,omitempty"`
-	// Do not verify tls certificates
-	Insecure bool `json:"insecure,omitempty"`
-	// Force allow use of non-ssl
-	ForceNonSSL bool `json:"forceNonSSL,omitempty"`
-	// Certificate secret name for private registry. Secret's data key must be 'ca.crt' or 'tls.crt'.
+	// The name of certificate secret for private registry.
 	CertificateSecret string `json:"certificateSecret,omitempty"`
-	// Login id and password secret object for registry
+	// The name of secret containing login credential of registry
 	ImagePullSecret string `json:"imagePullSecret,omitempty"`
-	// Debug flag
-	Debug bool `json:"debug,omitempty"`
-	// Skip pinging the registry while establishing connection
-	SkipPing bool `json:"skipPing,omitempty"`
-	// Timeout for HTTP requests
-	TimeOut time.Duration `json:"timeOut,omitempty"`
-	// Number of fixable issues permitted
-	FixableThreshold int `json:"fixableThreshold,omitempty"`
-	// Send vulerability to ES
-	ElasticSearch bool `json:"elasticSearch,omitempty"`
 }
 
 // ScanResult is result of scanning an image
@@ -86,7 +68,6 @@ type Vulnerability struct {
 	Severity string `json:"Severity,omitempty"`
 	// Metadata
 	//Metadata runtime.RawExtension `json:"Metadata,omitempty"`
-
 	// Fixed version
 	FixedBy string `json:"FixedBy,omitempty"`
 }
@@ -100,6 +81,12 @@ type Vulnerabilities []Vulnerability
 // ImageScanRequestSpec defines the desired state of ImageScanRequest
 type ImageScanRequestSpec struct {
 	ScanTargets []ScanTarget `json:"scanTargets"`
+	// Do not verify registry server's certificate
+	Insecure bool `json:"insecure",omitempty`
+	// The number of fixable issues allowable
+	MaxFixable int `json:"maxFixable,omitempty"`
+	// Whether to send result to report server
+	SendReport bool `json:"sendReport,omitempty"`
 }
 
 // ImageScanRequestStatus defines the observed state of ImageScanRequest

--- a/api/v1/imagescanrequest_types.go
+++ b/api/v1/imagescanrequest_types.go
@@ -82,7 +82,7 @@ type Vulnerabilities []Vulnerability
 type ImageScanRequestSpec struct {
 	ScanTargets []ScanTarget `json:"scanTargets"`
 	// Do not verify registry server's certificate
-	Insecure bool `json:"insecure",omitempty`
+	Insecure bool `json:"insecure,omitempty"`
 	// The number of fixable issues allowable
 	MaxFixable int `json:"maxFixable,omitempty"`
 	// Whether to send result to report server

--- a/config/crd/bases/tmax.io_imagescanrequests.yaml
+++ b/config/crd/bases/tmax.io_imagescanrequests.yaml
@@ -79,7 +79,6 @@ spec:
               description: Whether to send result to report server
               type: boolean
           required:
-          - insecure
           - scanTargets
           type: object
         status:

--- a/config/crd/bases/tmax.io_imagescanrequests.yaml
+++ b/config/crd/bases/tmax.io_imagescanrequests.yaml
@@ -45,57 +45,41 @@ spec:
         spec:
           description: ImageScanRequestSpec defines the desired state of ImageScanRequest
           properties:
+            insecure:
+              description: Do not verify registry server's certificate
+              type: boolean
+            maxFixable:
+              description: The number of fixable issues allowable
+              type: integer
             scanTargets:
               items:
                 description: ScanTarget is a target setting to scan images
                 properties:
-                  authUrl:
-                    description: 'Alternate URL for registry authentication (example:
-                      auth.docker.io)'
-                    type: string
                   certificateSecret:
-                    description: Certificate secret name for private registry. Secret's
-                      data key must be 'ca.crt' or 'tls.crt'.
+                    description: The name of certificate secret for private registry.
                     type: string
-                  debug:
-                    description: Debug flag
-                    type: boolean
-                  elasticSearch:
-                    description: Send vulerability to ES
-                    type: boolean
-                  fixableThreshold:
-                    description: Number of fixable issues permitted
-                    type: integer
-                  forceNonSSL:
-                    description: Force allow use of non-ssl
-                    type: boolean
                   imagePullSecret:
-                    description: Login id and password secret object for registry
+                    description: The name of secret containing login credential of
+                      registry
                     type: string
                   images:
                     description: 'Image path (example: library/alpine:3)'
                     items:
                       type: string
                     type: array
-                  insecure:
-                    description: Do not verify tls certificates
-                    type: boolean
                   registryUrl:
                     description: 'Registry URL (example: docker.io)'
                     type: string
-                  skipPing:
-                    description: Skip pinging the registry while establishing connection
-                    type: boolean
-                  timeOut:
-                    description: Timeout for HTTP requests
-                    format: int64
-                    type: integer
                 required:
                 - images
                 - registryUrl
                 type: object
               type: array
+            sendReport:
+              description: Whether to send result to report server
+              type: boolean
           required:
+          - insecure
           - scanTargets
           type: object
         status:
@@ -132,7 +116,8 @@ spec:
                             description: Description for severity
                             type: string
                           FixedBy:
-                            description: Fixed version
+                            description: Metadata Metadata runtime.RawExtension `json:"Metadata,omitempty"`
+                              Fixed version
                             type: string
                           Link:
                             description: Description link

--- a/config/manager/manager_config.yaml
+++ b/config/manager/manager_config.yaml
@@ -25,10 +25,12 @@ data:
         image_pull_secret: ""
     keycloak:
       service: https://172.22.11.9:8443
-    clair:
-      url: "http://clair.registry-system.svc.cluster.local:6060"
-    elastic_search:
-      url: "http://elasticsearch.kube-logging.svc.cluster.local:9200"
+    scanning:
+      scanner:
+        url: "http://clair.registry-system.svc.cluster.local:6060"
+        insecure: false
+      report:
+        url: "http://elasticsearch.kube-logging.svc.cluster.local:9200"
     harbor:
       namespace: harbor
       core:

--- a/config/manager/manager_dev.yaml
+++ b/config/manager/manager_dev.yaml
@@ -46,6 +46,8 @@ spec:
                 secretKeyRef:
                   name: keycloak-secret
                   key: password
+          - name: ENV
+            value: "dev"
         volumeMounts:
         - name: manager-mnt
           mountPath: /bin/dev

--- a/controllers/imagescanrequest_controller.go
+++ b/controllers/imagescanrequest_controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -53,17 +54,38 @@ type ImageScanRequestReconciler struct {
 
 var (
 	worker *scanctl.ScanWorker
+	// FIXME: Remove clair library dependency
+	scanner *clair.Clair
+	verbose = false
 )
 
 const (
 	requestQueueSize = 100
 	nWorkers         = 5
+	timeout          = time.Second * 3
 )
 
 func init() {
 	// TODO: Load value from operator config
 	worker = scanctl.NewScanWorker(requestQueueSize, nWorkers)
 	worker.Start()
+
+	// FIXME: Promote using ENV env to operator scope
+	switch os.Getenv("ENV") {
+	case "dev":
+		verbose = true
+	case "prod":
+		verbose = false
+	default:
+		verbose = true
+	}
+
+	// FIXME: Regenerate instance on change manager config
+	scanner, _ = clair.New(config.Config.GetString(config.ConfigImageScanSvr), clair.Opt{
+		Debug:    verbose,
+		Timeout:  timeout,
+		Insecure: config.Config.GetBool("scanning.scanner.insecure"),
+	})
 }
 
 // +kubebuilder:rbac:groups=tmax.io,resources=imagescanrequests,verbs=get;list;watch;create;update;patch;delete
@@ -117,26 +139,13 @@ func (r *ImageScanRequestReconciler) doRecept(instance *tmaxiov1.ImageScanReques
 	// validation phase
 	// TODO: Move this to validation webhook
 	for _, e := range instance.Spec.ScanTargets {
-		if !e.Insecure && !strings.HasPrefix(e.RegistryURL, "https:") {
-			return fmt.Errorf("Invalid url. Add prefix 'https' to registry URL")
-		}
-
-		if e.FixableThreshold < 0 {
-			return fmt.Errorf("fixable threshold must be a positive integer")
+		if !instance.Spec.Insecure && !strings.HasPrefix(e.RegistryURL, "https:") {
+			return fmt.Errorf("Invalid registry URL included. Add prefix 'https' to registry URL")
 		}
 	}
 
-	// XXX: Move this to global scope if operator only comuunicate with a single clair server
-	// -> then how to regenerate object when on manager.config changed?
-
-	// FIXME: Load clair connection settings from operator
-	clairCli, err := clair.New(config.Config.GetString(config.ConfigClairURL), clair.Opt{
-		Debug:    false,
-		Timeout:  time.Second,
-		Insecure: true,
-	})
-	if err != nil {
-		return err
+	if instance.Spec.MaxFixable < 0 {
+		return fmt.Errorf("fixable threshold must be a positive integer")
 	}
 
 	// preprocess phase
@@ -171,13 +180,11 @@ func (r *ImageScanRequestReconciler) doRecept(instance *tmaxiov1.ImageScanReques
 
 		username := ""
 		password := ""
-		// XXX: Is it right to handle default docker.io when empty registry url?
+		// XXX: Is it right default docker.io when empty registry url?
 		regUrl := "https://registry-1.docker.io"
 
 		if len(e.RegistryURL) > 0 && e.RegistryURL != "docker.io" {
 			regUrl = e.RegistryURL
-		} else if len(e.AuthURL) > 0 {
-			regUrl = e.AuthURL
 		}
 
 		if len(e.ImagePullSecret) > 0 {
@@ -204,30 +211,27 @@ func (r *ImageScanRequestReconciler) doRecept(instance *tmaxiov1.ImageScanReques
 			password = string(login.Password)
 		}
 
-		// get auth config
 		authCfg, err := repoutils.GetAuthConfig(username, password, regUrl)
 		if err != nil {
 			return err
 		}
 
-		// Create the registry client.
 		r, err := secureReg.New(context.TODO(), authCfg, registry.Opt{
-			Insecure: e.Insecure,
-			Debug:    e.Debug,
-			SkipPing: e.SkipPing,
-			NonSSL:   e.ForceNonSSL,
-			Timeout:  e.TimeOut,
+			Insecure: instance.Spec.Insecure,
+			Debug:    verbose,
+			SkipPing: false,
+			Timeout:  timeout,
 		}, tlsCertData)
 		if err != nil {
 			return err
 		}
 
-		job := scanctl.NewScanJob(r, clairCli, e.Images, e.FixableThreshold, e.ElasticSearch)
+		job := scanctl.NewScanJob(r, scanner, e.Images, instance.Spec.MaxFixable, instance.Spec.SendReport)
 		jobs = append(jobs, job)
 	}
 
 	// TODO: Load config value from operator config
-	es := scanctl.NewReportClient(config.Config.GetString(config.ConfigElasticSearchURL),
+	es := scanctl.NewReportClient(config.Config.GetString(config.ConfigImageReportSvr),
 		&http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,

--- a/controllers/imagescanrequest_controller.go
+++ b/controllers/imagescanrequest_controller.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/genuinetools/reg/clair"
@@ -138,12 +137,6 @@ func (r *ImageScanRequestReconciler) doRecept(instance *tmaxiov1.ImageScanReques
 
 	// validation phase
 	// TODO: Move this to validation webhook
-	for _, e := range instance.Spec.ScanTargets {
-		if !instance.Spec.Insecure && !strings.HasPrefix(e.RegistryURL, "https:") {
-			return fmt.Errorf("Invalid registry URL included. Add prefix 'https' to registry URL")
-		}
-	}
-
 	if instance.Spec.MaxFixable < 0 {
 		return fmt.Errorf("fixable threshold must be a positive integer")
 	}

--- a/docs/usage/imagescanrequest.md
+++ b/docs/usage/imagescanrequest.md
@@ -2,7 +2,7 @@
 
 ## **What is it?**
 
-ImageScanRequest represents the current image scanning state against the Clair which installed on with operator. It can also sending a scan report to elasticsearch and a user can view statistics from Kibana.
+ImageScan Request displays a list of images that need to be scanned from the image scan server and the processed results. It can also send the scan reports to elasticsearch server.
 
 ## How to create
 
@@ -11,17 +11,18 @@ ImageScanRequest represents the current image scanning state against the Clair w
 **Key**|**Requried**|**Type**|**Description**
 :-----:|:-----:|:-----:|:-----:
 scanTargets|Yes|[]scanTarget|The bunch of target to be scanned which under the same registry.
+insecure|No|bool|Do not verify registry server's certificate
+sendReport|No|bool|Whether to send result to report server(elasticsearch)
+maxFixable|No|bool|The number of fixable issues allowable
 
 ### spec.scanTargets field
 
 **Key**|**Requried**|**Type**|**Description**
 :-----:|:-----:|:-----:|:-----:
-registryURL|Yes|string|The URL of container registry.
-certifacateSecret|No|string|The secret name which contains a container registry's certificate keypair (TLS Secret recommended)
+registryURL|Yes|string|The image registry address.
+certifacateSecret|No|string|The name of certificate secret for private registry. If secret is 'Opaque' type, the key of certificate should be 'ca.crt' or 'tls.crt';TLS type secret is recommended
 images|Yes|[]string|Image names to scan ('*' for all and '?' for regex can be used)
-imagePullSecret|No|string|The secret name which contains a login credential for registry (Should be DockerConfigJson type)
-insecure|No|bool|Allow insecure registry connection when using SSL
-elasticSearch|No|bool|whether send vulunerability reports to elasticsearch
+imagePullSecret|No|string|The name of secret containing login credential of registry (The secret should be 'DockerConfigJson' type)
 
 ## Example
 
@@ -33,14 +34,14 @@ Scan each of images
 apiVersion: tmax.io/v1
 kind: ImageScanRequest
 metadata:
-  name: 
+  name: poc-base-images
 spec:
 scanTargets:
 - registryUrl: "220.90.208.243"
   images: ["nginx:1.18.0","redis:5.0.10","golang:1.14.14","tomcat:8.5"]
   certificateSecret: poc-registry-cert
   imagePullSecret: hpcd-registry-tmax-registry
-  elasticSearch: true
+sendReport: true
 ```
 
 Scan all images in the repository
@@ -49,14 +50,14 @@ Scan all images in the repository
 apiVersion: tmax.io/v1
 kind: ImageScanRequest
 metadata:
-  name:
+  name: poc-all
 spec:
 scanTargets:
 - registryUrl: "220.90.208.243"
   images: ["*"]
   certificateSecret: poc-registry-cert
   imagePullSecret: hpcd-registry-tmax-registry
-  elasticSearch: true
+sendReport: true
 ```
 
 ## **Result**

--- a/internal/common/config/env.go
+++ b/internal/common/config/env.go
@@ -9,10 +9,10 @@ const (
 	ConfigKeycloakService = "keycloak.service"
 	// ConfigClusterName is the key to get cluster.name config
 	ConfigClusterName = "cluster.name"
-	// ConfigClairURL is the key to get clair.url config
-	ConfigClairURL = "clair.url"
-	// ConfigElasticSearchURL is the key to get elastic_search.url config
-	ConfigElasticSearchURL = "elastic_search.url"
+	// ConfigImageScanSvr is the key to get clair.url config
+	ConfigImageScanSvr = "scanning.scanner.url"
+	// ConfigImageReportSvr is the key to get elastic_search.url config
+	ConfigImageReportSvr = "scanning.report.url"
 	// ConfigHarborNamespace is the key to get harbor.namespace config
 	ConfigHarborNamespace = "harbor.namespace"
 	// ConfigHarborCoreIngress is the key to get harbor.core.ingress config

--- a/pkg/apiserver/apis/v1/scanrequest.go
+++ b/pkg/apiserver/apis/v1/scanrequest.go
@@ -175,8 +175,6 @@ func newImageScanReq(name, ns string, reqBody *scan.Request) (*v1.ImageScanReque
 			Images:          repoUrls,
 			ImagePullSecret: regCred,
 			RegistryURL:     strings.TrimPrefix(regObj.Status.ServerURL, "https://"),
-			ElasticSearch:   true,
-			Insecure:        true,
 		})
 	}
 
@@ -187,6 +185,8 @@ func newImageScanReq(name, ns string, reqBody *scan.Request) (*v1.ImageScanReque
 		},
 		Spec: v1.ImageScanRequestSpec{
 			ScanTargets: targets,
+			SendReport:  true,
+			Insecure:    true,
 		},
 	}, nil
 }
@@ -245,8 +245,6 @@ func newExtImageScanReq(name, ns string, reqBody *scan.Request) (*v1.ImageScanRe
 			ImagePullSecret:   regObj.Spec.ImagePullSecret,
 			CertificateSecret: regObj.Spec.CertificateSecret,
 			RegistryURL:       strings.TrimPrefix(regObj.Spec.RegistryURL, "https://"),
-			ElasticSearch:     true,
-			Insecure:          regObj.Spec.Insecure,
 		})
 	}
 
@@ -257,6 +255,8 @@ func newExtImageScanReq(name, ns string, reqBody *scan.Request) (*v1.ImageScanRe
 		},
 		Spec: v1.ImageScanRequestSpec{
 			ScanTargets: targets,
+			SendReport:  true,
+			Insecure:    true,
 		},
 	}, nil
 }

--- a/pkg/apiserver/apis/v1/scanresult.go
+++ b/pkg/apiserver/apis/v1/scanresult.go
@@ -331,7 +331,7 @@ func getScanResultFromExternal(req *http.Request) (map[string]scan.ResultRespons
 	}
 
 	// Initialize clair client.
-	cr, err := clair.New(config.Config.GetString(config.ConfigClairURL), clair.Opt{
+	cr, err := clair.New(config.Config.GetString(config.ConfigImageScanSvr), clair.Opt{
 		Debug:    false,
 		Timeout:  time.Second * 3,
 		Insecure: false,

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -88,7 +88,7 @@ func GetScanResult(img *image.Image) (ResultResponse, error) {
 }
 
 func fetchClairResult(layerId string) (*ClairResponse, error) {
-	clairServer := config.Config.GetString(config.ConfigClairURL)
+	clairServer := config.Config.GetString(config.ConfigImageScanSvr)
 	if clairServer == "" {
 		return nil, fmt.Errorf("CLAIR_URL is not set")
 	}


### PR DESCRIPTION
- ImageScanRequest.Spec.ScanTarget에서 ScanTarget 자체와 관련없는 필드들 제거 혹은 이동
- scanning 관련 manager_config 필드명 변경
- ImageScanRequest마다 scanner 인스턴스를 새로 생성하지 않고, 오퍼레이터 기동 시 생성한 단일 인스턴스 참조하도록 수정
- 오퍼레이터 기동 옵션(ENV=dev,prod)에 따른 레지스트리 및 스캐너 클라이언트 로그 출력